### PR TITLE
add dependency to jaxb for Java > 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
       <version>1.7.26</version>
     </dependency>
 
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.4</version>
     </dependency>
     
   </dependencies>
@@ -146,4 +146,3 @@
   </build>
 
 </project>
-


### PR DESCRIPTION
Maybe there are more elegant solutions, but this works on Java 11