### PR TITLE
chore(release): bump versions for 7.16 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- set the version for Camunda Platform here -->
-    <version.camunda>7.15.0</version.camunda>
+    <version.camunda>7.16.0</version.camunda>
     <version.junit>4.13.1</version.junit>
-    <version.h2>1.4.190</version.h2>
-    <version.camunda.assert>10.0.0</version.camunda.assert>
-    <version.assertj>3.18.1</version.assertj>
+    <version.h2>1.4.200</version.h2>
+    <version.camunda.assert>13.0.0</version.camunda.assert>
+    <version.assertj>3.20.2</version.assertj>
 
     <!-- set the java version here -->
     <version.java>1.8</version.java>


### PR DESCRIPTION
* bumps Camunda to 7.16.0
* bumps H2 to 1.4.200
* bumps Camunda Assert to 13.0.0
* bumps AssertJ to 3.20.2

related to CAM-13917